### PR TITLE
Update link to "Java is Still Free" in FAQ

### DIFF
--- a/src/handlebars/faq.handlebars
+++ b/src/handlebars/faq.handlebars
@@ -152,7 +152,7 @@
     <div class="margin-bottom">
 
     <p>We fully support the notion that
-    <a href="https://medium.com/@javachampions/java-is-still-free-c02aef8c9e04">
+    <a href="https://medium.com/@javachampions/java-is-still-free-2-0-0-6b9aa8d6d244">
     Java Is Still Free</a>.  The JDK and JRE binaries we produce are
     published under the GPLv2 with Classpath Exception and OpenJDK Assembly
     Exception (often referred to as GPL2+CE), and you don’t have any


### PR DESCRIPTION
This updates the link of the "Java is Still Free" post on Medium to a newer version.
There is a notice on the original post to only read this version for historical context:
> A NEWER VERSION (2.0.1) HAS BEEN RELEASED — PLEASE ONLY READ THIS DOCUMENT FOR HISTORICAL CONTEXT

##### Checklist
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
